### PR TITLE
Remove trailing whitespace in annotation block

### DIFF
--- a/AutoPageClassAnnotations.module.php
+++ b/AutoPageClassAnnotations.module.php
@@ -201,7 +201,7 @@ class AutoPageClassAnnotations extends WireData implements Module {
     protected function generatePageClassAnnotation(Template $template): void {
         $className = ucfirst($this->wire()->sanitizer->camelCase($template->name)) . 'Page';
 
-        $annotations = " * \n";
+        $annotations = " *\n";
         $templateName = $template->name;
         if ($template->label) {
             $templateName .= " ($template->label)";


### PR DESCRIPTION
For those with code editors that highlight trailing whitespace at the end of lines.