### PR TITLE
Support generation of Page files with strict_types

### DIFF
--- a/AutoPageClassAnnotations.module.php
+++ b/AutoPageClassAnnotations.module.php
@@ -242,6 +242,10 @@ class AutoPageClassAnnotations extends WireData implements Module {
     protected function createPageClassFile(string $className, Template $template): void {
         $filePath = config()->paths()->classes . $className . '.php';
         $fileContent = "<?php namespace ProcessWire;\n\n";
+        $use_strict_preamble = (bool) ($this->wire()->config->AutoPageClassAnnotationsStrictPreamble ?? false);
+        if ($use_strict_preamble) {
+            $fileContent = "<?php declare(strict_types=1);\n\nnamespace ProcessWire;\n\n";
+        }
         $baseClassName = 'Page';
         if ($template->pageClass !== '') {
             $baseClassName = $template->pageClass;


### PR DESCRIPTION
**Proposal**: use a config setting to turn on generation of new Page files with `declare(strict_types=1)` at the start.

Set `$config->AutoPageClassAnnotationsStrictPreamble = true;` in your config.php to enable this.

An alternative might be to convert this to a configurable module - but this seems like an easy first step.